### PR TITLE
ajy-UID2-1490-Redirect-euid-privacy-link

### DIFF
--- a/views_euid/index.hbs
+++ b/views_euid/index.hbs
@@ -72,6 +72,13 @@
       <img class='main__logo' src='/images/EUID.png' />
     </div>
   </div>
+  <script> 
+    window.onload = function () {
+      if (window.location.href.includes('#/privacynotice')) {
+        window.location.href = '/privacy';
+      }
+    };
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
Redirect #/privacynotice to /privacy on index view. From the research I have done, it seems like placing this at the bottom of the <body> is the right thing to do, so that it doesn't block the rest of the page loading.


https://github.com/IABTechLab/uid2-tcportal/assets/137864392/2822e931-d2d4-43a1-93c5-2cf97f7ecba2

