### PR TITLE
Fix app crashing when bot code causes an error

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -149,12 +149,14 @@ const defaultRouteHandler: RequestHandler<{}, {}, z.infer<typeof DefaultRouteReq
   }
 
   if (!step) {
-    throw new Error('no step');
+      logger.log('error', `no step`);
+      return;
   }
   
   const handler = Object.prototype.hasOwnProperty.call(steps, step) && steps[step];
   if (!handler) {
-    throw new Error(`invalid step ${step}`);
+    logger.log('error', `invalid step ${step}`);
+    return;
   }
 
   await handler(req, res, next);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -138,21 +138,25 @@ const DefaultRouteRequest = z.object({
 });
 
 const defaultRouteHandler: RequestHandler<{}, {}, z.infer<typeof DefaultRouteRequest>> = async (req, res, next) => {
+  let step;
+
   try {
-    const { step } = DefaultRouteRequest.parse(req.body);
-    if (!step) {
-      throw new Error('no step');
-    }
-    const handler = Object.prototype.hasOwnProperty.call(steps, step) && steps[step];
-    if (!handler) {
-      throw new Error(`invalid step ${step}`);
-    }
-  
-    await handler(req, res, next);
+    step = DefaultRouteRequest.parse(req.body).step; 
   }
   catch (e) {
       logger.log('error', `error while parsing the request`);
+      return;
   }
+
+  if (!step) {
+    throw new Error('no step');
+  }
+  const handler = Object.prototype.hasOwnProperty.call(steps, step) && steps[step];
+  if (!handler) {
+    throw new Error(`invalid step ${step}`);
+  }
+
+  await handler(req, res, next);
 
 
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -151,6 +151,7 @@ const defaultRouteHandler: RequestHandler<{}, {}, z.infer<typeof DefaultRouteReq
   if (!step) {
     throw new Error('no step');
   }
+  
   const handler = Object.prototype.hasOwnProperty.call(steps, step) && steps[step];
   if (!handler) {
     throw new Error(`invalid step ${step}`);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -138,17 +138,28 @@ const DefaultRouteRequest = z.object({
 });
 
 const defaultRouteHandler: RequestHandler<{}, {}, z.infer<typeof DefaultRouteRequest>> = async (req, res, next) => {
-  const { step } = DefaultRouteRequest.parse(req.body);
-  if (!step) {
-    throw new Error('no step');
+  try {
+    const { step } = DefaultRouteRequest.parse(req.body);
+    if (!step) {
+      throw new Error('no step');
+    }
+    const handler = Object.prototype.hasOwnProperty.call(steps, step) && steps[step];
+    if (!handler) {
+      throw new Error(`invalid step ${step}`);
+    }
+  
+    await handler(req, res, next);
+  }
+  catch (e) {
+    if (e instanceof Error) {
+      logger.log('error', `error while parsing the request`);
+    }
+   
   }
 
-  const handler = Object.prototype.hasOwnProperty.call(steps, step) && steps[step];
-  if (!handler) {
-    throw new Error(`invalid step ${step}`);
-  }
 
-  await handler(req, res, next);
+
+
 };
 
 router.post('/', defaultRouteHandler);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -151,10 +151,7 @@ const defaultRouteHandler: RequestHandler<{}, {}, z.infer<typeof DefaultRouteReq
     await handler(req, res, next);
   }
   catch (e) {
-    if (e instanceof Error) {
       logger.log('error', `error while parsing the request`);
-    }
-   
   }
 
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -157,10 +157,6 @@ const defaultRouteHandler: RequestHandler<{}, {}, z.infer<typeof DefaultRouteReq
   }
 
   await handler(req, res, next);
-
-
-
-
 };
 
 router.post('/', defaultRouteHandler);


### PR DESCRIPTION
App was crashing when botnet traffic tried to send information to TCPortal

The Fix: adding a try-catch block and logging the error instead of an error thrown inside the Zod code

Test plan:
*Must have local operator running*
Open Powershell ISE and paste this example script into the file:
```
$params = @{"@type"="login";
 "username"="xxx@gmail.com";
 "password"="yyy";
}

Invoke-WebRequest -Uri http://localhost:3000/ -Method POST -Body $params
```

Run `yarn euid` in the terminal of the TCPortal code, then run the above script in ISE.  Make sure the app does not crash, but instead logs the error and stays running.  Go to the EUID TCPortal on `localhost:3000`, enter a valid email, and make sure the app is still working after the error. 
