### PR TITLE
Run lint as part of Build and Test pipeline

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -17,6 +17,8 @@ jobs:
       - run: yarn install
       - name: build 
         run: yarn build
+      - name: lint 
+        run: yarn lint
       - name: test
         #TODO Remove this when we have tests
         run: yarn test --passWithNoTests

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -143,8 +143,8 @@ const defaultRouteHandler: RequestHandler<{}, {}, z.infer<typeof DefaultRouteReq
   try {
     step = DefaultRouteRequest.parse(req.body).step; 
   } catch (e) {
-    logger.log('error', 'error while parsing the request');
-    return;
+      logger.log('error', 'error while parsing the request');
+      return;
   }
 
   if (!step) {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -143,8 +143,8 @@ const defaultRouteHandler: RequestHandler<{}, {}, z.infer<typeof DefaultRouteReq
   try {
     step = DefaultRouteRequest.parse(req.body).step; 
   } catch (e) {
-      logger.log('error', 'error while parsing the request');
-      return;
+    logger.log('error', 'error while parsing the request');
+    return;
   }
 
   if (!step) {


### PR DESCRIPTION
Run lint as part of the build-and-test pipeline which is triggered in PRs.

Example of a PR run on this branch with a lint error causing the pipeline to fail: https://github.com/IABTechLab/uid2-tcportal/actions/runs/10675298062/job/29587064518?pr=69 (see this [commit](https://github.com/IABTechLab/uid2-tcportal/pull/69/commits/f9f5bcbdd4af12ada1a4e1588772c042f50be0a0))