### PR TITLE
Prevent tcportal logging full request content with authorization

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,7 @@ import winston from 'winston';
 
 import makeMetricsApiMiddleware from './middleware/metrics';
 import indexRouter from './routes/index';
-import logger from './utils/logging';
+import logger, { getLoggingMiddleware } from './utils/logging';
 import {
   environment, ID_TYPE, LOCALE_FOLDER, VIEW_FOLDER, 
 } from './utils/process';
@@ -28,6 +28,8 @@ const viewPath = path.join(__dirname, VIEW_FOLDER);
 const layoutPath = path.join(viewPath, 'layouts');
 app.set('views', viewPath);
 app.set('view engine', 'hbs');
+
+app.use(getLoggingMiddleware());
 
 app.use(
   makeMetricsApiMiddleware({

--- a/src/routes/optout.ts
+++ b/src/routes/optout.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { Buffer } from 'buffer';
 import crypto from 'crypto';
 
-import { OPTOUT_API_SECRET, OPTOUT_ENDPOINT_URL } from '../utils/process';
+import { OPTOUT_API_KEY, OPTOUT_API_SECRET, OPTOUT_ENDPOINT_URL } from '../utils/process';
 
 interface Optout {
   phone?: string;
@@ -38,6 +38,7 @@ export async function optout(identityInput: string): Promise<any> {
   return axios.post(OPTOUT_ENDPOINT_URL, body,
     {
       headers: {
+        Authorization: `Bearer ${OPTOUT_API_KEY}`,
         'Content-Type': 'text/plain',
       },
     });

--- a/src/routes/optout.ts
+++ b/src/routes/optout.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { Buffer } from 'buffer';
 import crypto from 'crypto';
 
-import { OPTOUT_API_KEY, OPTOUT_API_SECRET, OPTOUT_ENDPOINT_URL } from '../utils/process';
+import { OPTOUT_API_SECRET, OPTOUT_ENDPOINT_URL } from '../utils/process';
 
 interface Optout {
   phone?: string;
@@ -38,7 +38,6 @@ export async function optout(identityInput: string): Promise<any> {
   return axios.post(OPTOUT_ENDPOINT_URL, body,
     {
       headers: {
-        Authorization: `Bearer ${OPTOUT_API_KEY}`,
         'Content-Type': 'text/plain',
       },
     });

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -13,8 +13,7 @@ const logger = createLogger({
 
 const headersToRedact = ['authorization'];
 
-export const getLoggingMiddleware = () =>
-  expressWinston.logger({
+export const getLoggingMiddleware = () => expressWinston.logger({
     winstonInstance: logger,
     headerBlacklist: headersToRedact,
   });

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,5 +1,5 @@
-import winston, { createLogger } from 'winston';
 import expressWinston from 'express-winston';
+import winston, { createLogger } from 'winston';
 
 import { isProduction } from './process';
 

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,4 +1,5 @@
 import winston, { createLogger } from 'winston';
+import expressWinston from 'express-winston';
 
 import { isProduction } from './process';
 
@@ -9,5 +10,13 @@ const logger = createLogger({
     }),
   ],
 });
+
+const headersToRedact = ['authorization'];
+
+export const getLoggingMiddleware = () =>
+  expressWinston.logger({
+    winstonInstance: logger,
+    headerBlacklist: headersToRedact,
+  });
 
 export default logger;

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -14,8 +14,8 @@ const logger = createLogger({
 const headersToRedact = ['authorization'];
 
 export const getLoggingMiddleware = () => expressWinston.logger({
-    winstonInstance: logger,
-    headerBlacklist: headersToRedact,
-  });
+  winstonInstance: logger,
+  headerBlacklist: headersToRedact,
+});
 
 export default logger;


### PR DESCRIPTION
What Changed:

1. Added blacklist for `authorization` header (see `loggingHelpers.ts` in uid2-self-serve-portal for reference)

Test Plan:

1. Run `yarn uid2` and also make sure local operator is running
2. Open Powershell ISE
3. Paste this script to add an authorization header 

```
$headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
$headers.Add('authorization','Bearer 123456')

Invoke-WebRequest -Uri http://localhost:3000/ -Headers $headers -Method GET 
```

4. Comment out line 32 in `app.ts` ( `//app.use(getLoggingMiddleware()`) to simulate the code before this PR, run the above command in ISE, and observe the authorization bearer token in the terminal logs
5. Uncomment out line 32, run the code in ISE again, and make sure the authorization header cannot be seen in the terminal logs
6. Run `yarn euid` and repeat steps 2-6.  


https://github.com/user-attachments/assets/cc107f70-b3ce-402d-a872-34670ef23bb6

