### PR TITLE
pass amazon trace id as service id

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -109,9 +109,10 @@ const OptoutSubmitRequest = z.object({
 
 const handleOptoutSubmit: RequestHandler<{}, { message: string } | { error: string }, z.infer<typeof OptoutSubmitRequest>> = async (req, res, _next) => {
   const { encrypted } = OptoutSubmitRequest.parse(req.body);
+  const serviceId = req.headers['X-Amzn-Trace-Id']?.toString() ?? 'service-id-unavailable';
   try {
     const payload = await decrypt(encrypted);
-    await optout(payload);
+    await optout(payload, serviceId);
 
   } catch (e) {
     res.render('index', { countryList, error : i18n.__('Sorry, we could not process your request.') });

--- a/src/routes/optout.ts
+++ b/src/routes/optout.ts
@@ -9,7 +9,7 @@ interface Optout {
   email?: string;
 }
 
-export async function optout(identityInput: string): Promise<any> {
+export async function optout(identityInput: string, serviceId: string): Promise<any> {
   const optoutInfo: Optout = {};
   if (identityInput[0] === '+') {
     optoutInfo.phone = identityInput;
@@ -40,6 +40,7 @@ export async function optout(identityInput: string): Promise<any> {
       headers: {
         Authorization: `Bearer ${OPTOUT_API_KEY}`,
         'Content-Type': 'text/plain',
+        'UID-Trace-Id': serviceId,
       },
     });
 }


### PR DESCRIPTION
X-Amzn-Trace-Id is added as a header by the Amazon load balancer. We want to pass that along in a new UID-Trace-Id header on logout calls to operator.

Screenshot shows the header being passed to operator with a placeholder value.

![image](https://github.com/user-attachments/assets/eb3a66f1-c0f6-4f35-8ffe-b2c7295eecf8)
