### PR TITLE
chore: upgrade GitHub Actions from Node 20 to Node 24

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -8,9 +8,9 @@ jobs:
     steps:
       # Check out repository $GITHUB_WORKSPACE
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: setup yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20.11.0'
           cache: 'yarn'

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -14,26 +14,26 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Get Package Version
         id: version
         run: |
           echo "::set-output name=package_version::$(cat package.json | jq -r '.version')"
       - name: Log in to the Container registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker (UID2)
         id: meta-uid2
-        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_UID2 }}
           tags: |
             type=sha,prefix=${{ steps.version.outputs.package_version }}-,format=short
       - name: Build and push Docker image (UID2)
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile_uid2
@@ -43,13 +43,13 @@ jobs:
           labels: ${{ steps.meta-uid2.outputs.labels }}
       - name: Extract metadata (tags, labels) for Docker (EUID)
         id: meta-euid
-        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_EUID }}
           tags: |
             type=sha,prefix=${{ steps.version.outputs.package_version }}-,format=short
       - name: Build and push Docker image (EUID)
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile_euid

--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -10,7 +10,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Vulnerability Scan
         uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
         with:

--- a/.github/workflows/release-tc-portal-image.yaml
+++ b/.github/workflows/release-tc-portal-image.yaml
@@ -51,7 +51,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Vulnerability Scan
         uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan@v3
         with:


### PR DESCRIPTION
Node 20 is being deprecated on GitHub Actions runners. Starting **June 16, 2026**, runners will use Node 24 by default.

This PR upgrades outdated action references in this repo to the latest released version that ships Node 24 support, pinned to its commit SHA. Each action's node version is determined by reading its `action.yml` at the pinned ref.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
