### PR TITLE
UID2-7292: prevent optout crash on malformed payload

### DIFF
--- a/src/bin/www.ts
+++ b/src/bin/www.ts
@@ -5,7 +5,8 @@ import { getLoggers } from '../utils/loggingHelpers';
 import { PORT } from '../utils/process';
 
 const server = http.createServer(app);
-const { localLogger } = getLoggers();
+const { localLogger, errorLogger } = getLoggers();
+const processTraceId = { traceId: 'process', uidTraceId: 'process' };
 
 function isHttpError(error: Error): error is Error & { syscall: string; code: string } {
   return Object.prototype.hasOwnProperty.call(error, 'syscall') && Object.prototype.hasOwnProperty.call(error, 'code');
@@ -13,6 +14,15 @@ function isHttpError(error: Error): error is Error & { syscall: string; code: st
 
 process.on('SIGINT', () => {
   process.exit();
+});
+
+// Diagnostic only: per-handler try/catch is the real defence. This listener exists
+// so any rejection that still escapes gets logged to the monitoring pipeline before
+// Node's default behaviour takes over. We deliberately do NOT add an uncaughtException
+// handler — Node's docs are explicit that resuming after one leaves the process in
+// an undefined state; the pod supervisor will restart us cleanly instead.
+process.on('unhandledRejection', (reason) => {
+  errorLogger.error(`Unhandled rejection: ${reason instanceof Error ? (reason.stack ?? reason.message) : String(reason)}`, processTraceId);
 });
 
 /**

--- a/src/routes/encryption.ts
+++ b/src/routes/encryption.ts
@@ -34,31 +34,45 @@ export async function decrypt(input: string): Promise<string> {
   }
 
   const iv = Uint8Array.from(Buffer.from(parts[0], 'base64'));
+  // aes-128-cbc requires a 16-byte IV; reject a bad length up front. This throw is
+  // synchronous within the async function, so it surfaces as a promise rejection
+  // the caller can catch (unlike a throw inside the scrypt callback below).
+  if (iv.length !== 16) {
+    throw new Error('Invalid Enrypted payload');
+  }
   return new Promise((resolve, reject) => {
     crypto.scrypt(SYSTEM_SECRET, SYSTEM_SALT, 16, (err, key) => {
       if (err) {
         reject(err);
         return;
       }
-    
-      const decipher = crypto.createDecipheriv(algo, key, iv);
-    
-      let decrypted = '';
-      decipher.on('readable', () => {
-        let chunk = decipher.read();
-        while (chunk) {
-          decrypted += chunk.toString('utf8');
-          chunk = decipher.read();
-        }
-      });
-    
-      decipher.on('end', () => {
-        resolve(decrypted);
-      });
-    
-      decipher.write(parts[1], 'base64');
-      decipher.end();
-    
+
+      // createDecipheriv and the stream write/end run inside this native callback;
+      // a throw here escapes the Promise and becomes an uncaught exception. Wrap them
+      // and route every failure (including the decipher 'error' event for bad padding)
+      // through reject so the caller's try/catch handles it.
+      try {
+        const decipher = crypto.createDecipheriv(algo, key, iv);
+        decipher.on('error', reject);
+
+        let decrypted = '';
+        decipher.on('readable', () => {
+          let chunk = decipher.read();
+          while (chunk) {
+            decrypted += chunk.toString('utf8');
+            chunk = decipher.read();
+          }
+        });
+
+        decipher.on('end', () => {
+          resolve(decrypted);
+        });
+
+        decipher.write(parts[1], 'base64');
+        decipher.end();
+      } catch (e) {
+        reject(e);
+      }
     });
   });
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -112,9 +112,20 @@ const OptoutSubmitRequest = z.object({
   encrypted: z.string(),
 });
 
-const handleOptoutSubmit: RequestHandler<{}, { message: string } | { error: string }, z.infer<typeof OptoutSubmitRequest>> = async (req, res, _next) => {
-  const { encrypted } = OptoutSubmitRequest.parse(req.body);
+const handleOptoutSubmit: RequestHandler<{}, { message: string } | { error: string }, z.infer<typeof OptoutSubmitRequest>> = async (req, res, next) => {
   const traceId = getTraceId(req);
+  // Validate inside try/catch: a malformed body (e.g. `encrypted` not a string)
+  // makes .parse() throw a ZodError. In an async handler an uncaught throw becomes
+  // an unhandled rejection that crashes the process rather than reaching the Express
+  // error handler, so reject it explicitly with a 400.
+  let encrypted: string;
+  try {
+    ({ encrypted } = OptoutSubmitRequest.parse(req.body));
+  } catch (e) {
+    errorLogger.error('error while parsing optout submit request', traceId);
+    next(createError(400));
+    return;
+  }
   const instanceId = SERVICE_INSTANCE_ID_PREFIX;
   const clientIp = (req.headers['x-forwarded-for'] as string)?.split(',')[0].trim() || req.ip || 'unknown';
   try {


### PR DESCRIPTION
## Why

A malformed payload to `POST /` (`step=optout_submit`) was crashing the Node process. Two distinct paths could escape as unhandled rejections / uncaught exceptions:

1. **`decrypt()` in `src/routes/encryption.ts`.** `crypto.scrypt`'s native callback contained synchronous code (`createDecipheriv`, `decipher.write`, `decipher.end`) sitting outside the Promise's `try` scope. A throw from any of those — most notably `createDecipheriv` rejecting an IV of the wrong length — escaped the Promise as an uncaught exception. The decipher stream's `'error'` event (bad padding from a wrong key or junk ciphertext) was also unobserved.
2. **`handleOptoutSubmit` in `src/routes/index.ts`.** `OptoutSubmitRequest.parse(req.body)` threw a `ZodError` directly inside the async route handler. With Express 4 having no native async-error forwarding, that throw became an unhandled rejection.

## What changed

**`src/routes/encryption.ts`**
- Reject a bad IV length (`!== 16`) synchronously before entering the `new Promise(...)` body, so the error surfaces as a normal Promise rejection the caller can `try/catch`.
- Wrap the `createDecipheriv` + stream setup inside the `scrypt` callback in `try/catch`, routing any throw through `reject`.
- Subscribe to the decipher's `'error'` event so async failures (bad padding) also reject the Promise instead of going unobserved.

**`src/routes/index.ts`**
- Wrap `OptoutSubmitRequest.parse(req.body)` in `try/catch`; on failure, log via `errorLogger` and respond with 400 via `next(createError(400))`.

**`src/bin/www.ts`**
- Add a diagnostic-only `unhandledRejection` listener that logs via `errorLogger` (so any future regression at least surfaces in monitoring).
- **No `uncaughtException` handler.** Node's docs are explicit that resuming after one leaves the process in undefined state; the pod supervisor (k8s) is the right restart mechanism.

## Follow-up (separate PR)

The file-level try/catch + `next(createError(400))` pattern is now duplicated three times in `src/routes/index.ts` (email_prompt, optout_submit, defaultRouteHandler). The right idiomatic fix is a centralized Express error middleware + a small `validateBody(schema)` middleware (and ideally an Express 4 → 5 upgrade so async handler rejections forward natively). Out of scope for a crash-fix PR; will follow up.

## Test plan

- [ ] CI build (`yarn build`) and lint pass
- [ ] `yarn test` passes locally
- [ ] Manual: POST malformed JSON to `/` → 400, no crash
- [ ] Manual: POST `{ step: 'optout_submit', encrypted: 'garbage' }` (wrong format) → friendly error page, no crash
- [ ] Manual: POST with IV slot that decodes to ≠16 bytes → friendly error page, no crash
- [ ] Manual: POST with valid IV but corrupted ciphertext (bad padding) → friendly error page, no crash, decipher `'error'` logged
- [ ] Manual: happy path optout still succeeds