### PR TITLE
UID2-7619: suppress CVE-2026-69152 in .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -35,3 +35,10 @@ CVE-2026-26996 exp:2027-02-20
 #
 # Expires: 2027-02-20 — revisit when eslint-plugin-import or ESLint is upgraded.
 CVE-2026-14257 exp:2027-02-20
+
+# CVE-2026-69152 — brace-expansion (npm, transitive via minimatch) (HIGH).
+# Not exploitable here: yarn.lock brace-expansion 1.1.16/2.1.2/5.0.7 all via devDependencies
+# (eslint-plugin-import->minimatch@3, jest/eslint tooling, nodemon->minimatch@10); existing
+# .trivyignore documents devDependency-only, not runtime-reachable
+# See: UID2-7619
+CVE-2026-69152 exp:2026-09-06

--- a/.trivyignore
+++ b/.trivyignore
@@ -41,4 +41,4 @@ CVE-2026-14257 exp:2027-02-20
 # (eslint-plugin-import->minimatch@3, jest/eslint tooling, nodemon->minimatch@10); existing
 # .trivyignore documents devDependency-only, not runtime-reachable
 # See: UID2-7619
-CVE-2026-69152 exp:2026-09-06
+CVE-2026-69152 exp:2026-11-06


### PR DESCRIPTION
Suppresses **CVE-2026-69152** (HIGH, `brace-expansion (npm, transitive via minimatch)`) — present in the image but not reachable from this service. Expiry **2026-11-06** (3 months). No code fix.

**Why:** brace-expansion is a build/lint/test-time transitive dependency (pulled through minimatch) in every flagged repo. The repos are Docusaurus documentation sites, static example apps, and a React+Express portal; none of their production runtime code imports brace-expansion, minimatch, or glob, and no production path passes attacker-controlled patterns to expand(). The advisory's DoS (unbounded intermediate arrays / event-loop block) requires reaching expand() with untrusted input, which is not reachable at runtime. A fixed 5.0.9 exists but availability does not change a not_affected verdict.

**Evidence:** package-lock.json:6291 brace-expansion@5.0.8 pulled only by minimatch@10.2.4 (dependencies: brace-expansion ^5.0.2); Docusaurus build/lint tooling; no brace-expansion/minimatch/glob import in src/ package-lock.json:6277 brace-expansion@5.0.8 via minimatch; Docusaurus static-docs build tooling only; no runtime import preview/package-lock.json:6291 brace-expansion@5.0.8 via minimatch; Docusaurus build-time only; no runtime import web-integrations/server-side/package-lock.json:600 brace-expansion@5.0.8 via minimatch@10.2.4 (dev/build tooling); server.js requires only axios/express/cookie-session/ejs/nocache/crypto; no minimatch/glob/brace-expansion on request path package-lock.json:11542 brace-expansion@5.0.8 via minimatch build/test tooling; no brace-expansion/minimatch/glob import in src/ (direct dep 'braces@3' is an unrelated package) yarn.lock brace-expansion 1.1.16/2.1.2/5.0.7 all via devDependencies (eslint-plugin-import->minimatch@3, jest/eslint tooling, nodemon->minimatch@10); existing .trivyignore documents devDependency-only, not runtime-reachable

Reachability alone determines suppress-vs-fix — a fixed version existing upstream does not make an unreachable path exploitable. Change the expiry in review if you want a different window.

<details>
<summary>Full triage report</summary>

### CVE-2026-69152 — brace-expansion DoS via unbounded intermediate arrays

#### What the CVE is
`brace-expansion` versions before 1.1.18 / 2.1.4 / 3.0.6 / 5.0.9 contain a denial-of-service flaw (GHSA-rgw5-rvv9-x895). The `maxLength` mitigation added in 5.0.8 for CVE-2026-14257 is incomplete: it bounds the accumulator in `combine()` but not the intermediate `values` array built from comma-alternatives before combining. A ~25 KB crafted brace pattern can trigger an **uncatchable** out-of-memory crash (a `try/catch` around `expand()` does not help), and a related path lets a ~400 KB input block the event loop for minutes. CVSS 3.1 HIGH (AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H) — availability impact only.

To be exploitable, production code must pass attacker-controlled strings to `brace-expansion.expand()` — typically indirectly via `minimatch`/`glob` pattern matching on untrusted input.

#### Where it appears in our repos
`brace-expansion@5.0.8` is present in all six flagged repos. In every case it is a **transitive dependency of `minimatch`** (`minimatch` declares `brace-expansion: ^5.0.2`), and `minimatch`/`glob` are consumed by build, lint, test, and dev tooling — not by request-handling code:

| Repo | How present | Reachable at runtime? |
|------|-------------|-----------------------|
| uid2docs | be@5.0.8 ← minimatch@10.2.4 (Docusaurus build, eslint) | No |
| EUID-docs | be@5.0.8 ← minimatch (Docusaurus build) | No |
| uid2-docs-preview | be@5.0.8 ← minimatch (Docusaurus build) | No |
| uid2-examples | be@5.0.8 ← minimatch@10.2.4 (dev/build tooling); Express `server.js` requires only axios/express/cookie-session/ejs/nocache/crypto | No |
| uid2-self-serve-portal | be@5.0.8 ← minimatch (build/test tooling); no runtime import in `src/` | No |
| uid2-tcportal | be 1.1.16/2.1.2/5.0.7 ← eslint-plugin-import, jest, nodemon (all devDependencies) | No |

Notes:
- The docs sites (uid2docs, EUID-docs, uid2-docs-preview) are Docusaurus projects that emit static HTML. `brace-expansion` is only exercised during `docusaurus build`/lint, never in a served request.
- In uid2-examples and uid2-self-serve-portal, grep of runtime source found **no** imports of `brace-expansion`, `minimatch`, or `glob`. (The portal's direct `braces@3` dependency is a different package and unrelated to this CVE.)
- uid2-tcportal already ships a `.trivyignore` entry documenting brace-expansion as devDependency-only and not runtime-reachable (aligned with the earlier CVE-2026-14257 suppression).

#### Decision
**not_affected.** The vulnerable `expand()` path is confined to build/lint/test tooling in all six repos; no production runtime code feeds attacker-controlled input to brace-expansion (directly or via minimatch/glob). The DoS therefore cannot be triggered against any of our deployed services. A fixed release (5.0.9) exists, but per triage policy the availability of a fix does not convert a non-reachable finding into an affected one.

#### Recommended action
**Suppress** this CVE for all six repos (record the standard tracking/expiry via the repo-root `.trivyignore`). tcportal already has an equivalent entry; the others can follow the same devDependency-only rationale. Optionally, on the next routine dependency bump, allow the transitive `brace-expansion` to float to ≥5.0.9 (e.g. via the existing `overrides`/`resolutions` pins) to clear the scanner without any runtime risk change — but this is hygiene, not a security necessity.

</details>

---
_Opened by uid2-vul-scan-agent (general_use_claude-opus-4-8), verdict confidence high. Please sanity-check the reachability argument before approving._